### PR TITLE
Add ability to find kanji

### DIFF
--- a/webview_util.py
+++ b/webview_util.py
@@ -1,5 +1,6 @@
 from aqt import mw, dialogs
 from aqt.qt import qconnect, QApplication
+from aqt.utils import tooltip
 
 from . import util
 
@@ -29,9 +30,34 @@ def on_browse_cmd(char, config, deckname):
 def on_search_cmd(char, wv, config):
     open_search_link(wv, config, char)
 
+def on_find_cmd(wv):
+    char = QApplication.clipboard().text()
+
+    # limit searches to kanji to prevent findText from highlighting UI text in the page
+    if not util.isKanji(char):
+        # truncate in case there's random garbage in the clipboard
+        LEN_LIMIT = 20
+        tooltip_char = char if len(char) <= LEN_LIMIT else char[:LEN_LIMIT] + "..."
+        tooltip(f"\"{tooltip_char}\" is not valid kanji.")
+        return
+    
+    # qt handles scrolling to, scrollbar indicator and opening the <details> block
+    wv.findText(char)
+
+    def blinkCharCallback(found: bool):
+        # findText doesn't tell us if it did anything, so we rely on blinkChar's ret
+        if not found:
+          tooltip(f"\"{char}\" not found in grid.")
+
+    # doesn't seem to be a way to style the text highlighting
+    # and it be hard to spot, so make the target blink
+    wv.evalWithCallback(f"blinkChar('{char}');", blinkCharCallback)
+
 def add_webview_context_menu_items(wv, expected_wv, menu, config, deckname, char):
     # hook is active while kanjigrid is open, and right clicking on the main window (deck list) will also trigger this, so check wv
-    if wv is expected_wv and char != "":
+    if wv is not expected_wv:
+      return
+    if char != "":
         menu.clear()
         copy_action = menu.addAction(f"Copy {char} to clipboard")
         qconnect(copy_action.triggered, lambda: on_copy_cmd(char))
@@ -39,3 +65,6 @@ def add_webview_context_menu_items(wv, expected_wv, menu, config, deckname, char
         qconnect(browse_action.triggered, lambda: on_browse_cmd(char, config, deckname))
         search_action = menu.addAction(f"Search online for {char}")
         qconnect(search_action.triggered, lambda: on_search_cmd(char, wv, config))
+    else:
+        find_action = menu.addAction(f"Find copied kanji")
+        qconnect(find_action.triggered, lambda: on_find_cmd(wv))


### PR DESCRIPTION
This is the implementation i've been using for the past week to deal with #25 

`QWebEngineView.findText` does tne heavy lifting (finding, scrolling, opening up \<details\>).

But it has a downside: i can't find any way to style the text highlighting. 
So i've added some js/css to make the found target blink for a bit (removed when exporting)

![image](https://github.com/user-attachments/assets/ab34225a-17d5-45ea-8095-15ca148876d7)
*Can you guess which kanji is highlighted?*

As for the choice of a context menu instead of something like a floating textbox,
- i don't know how to do that, not really a html/css guy 😅 
- the happy path would be coming across a kanji while mining and copypasting it in
- adding a textbox would be added complexity atop `on_find_cmd`

Also, anki finally got rid of the persistent `Copy` menu action in 24.11, so we could take a page out its book and only show the menu action when the clipboard has a valid kanji in it, but that would affect discoverability 🤔