### PR TITLE
Look for and load custom data files in the user_files dir

### DIFF
--- a/data.py
+++ b/data.py
@@ -24,13 +24,12 @@ groups = []
 def load_from_folder(groups, path):
     for file in os.listdir(path):
         filepath = path + "/" + file
-        with open(filepath, encoding = "utf-8") as f:
-            try:
-                grouping_json = json.loads(f.read())
-                groups.append(KanjiGroups(grouping_json["name"], grouping_json["source"], grouping_json["lang"], grouping_json["data"]))
-            except Exception:
-                # rethrow with msg in case a custom file in user_files is outdated
-                raise Exception(f"Failed to load Kanji Grid data file \"{file}\". It might be corrupted or outdated.")
+        try:
+            grouping_json = json.loads(open(filepath, "r", encoding = "utf-8").read())
+            groups.append(KanjiGroups(grouping_json["name"], grouping_json["source"], grouping_json["lang"], grouping_json["data"]))
+        except Exception:
+            # rethrow with msg in case a custom file in user_files is outdated
+            raise Exception(f"Failed to load Kanji Grid data file \"{file}\". It might be corrupted or outdated.")
 
 
 def init_groups():
@@ -41,9 +40,8 @@ def init_groups():
     load_from_folder(groups, data_folder)
 
     # user_files persists across addon updates
-    user_files_folder = cwd + "/user_files"
-    if not os.path.isdir(user_files_folder):
-        os.mkdir(user_files_folder)
-    load_from_folder(groups, user_files_folder)
+    user_data_folder = cwd + "/user_files/data"
+    os.makedirs(user_data_folder, exist_ok=True)
+    load_from_folder(groups, user_data_folder)
 
     groups.sort(key = lambda group: group.name)

--- a/data.py
+++ b/data.py
@@ -39,8 +39,10 @@ def init_groups():
     cwd = os.path.dirname(__file__)
     data_folder = cwd + "/data"
     load_from_folder(groups, data_folder)
-    # user_files persists through addon updates
+
+    # user_files persists across addon updates
     user_files_folder = cwd + "/user_files"
-    load_from_folder(groups, user_files_folder)
+    if os.path.exists(user_files_folder):
+        load_from_folder(groups, user_files_folder)
 
     groups.sort(key = lambda group: group.name)

--- a/data.py
+++ b/data.py
@@ -42,7 +42,8 @@ def init_groups():
 
     # user_files persists across addon updates
     user_files_folder = cwd + "/user_files"
-    if os.path.exists(user_files_folder):
-        load_from_folder(groups, user_files_folder)
+    if not os.path.isdir(user_files_folder):
+        os.mkdir(user_files_folder)
+    load_from_folder(groups, user_files_folder)
 
     groups.sort(key = lambda group: group.name)

--- a/data.py
+++ b/data.py
@@ -20,13 +20,27 @@ ignore = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + \
 
 groups = []
 
+
+def load_from_folder(groups, path):
+    for file in os.listdir(path):
+        filepath = path + "/" + file
+        with open(filepath, encoding = "utf-8") as f:
+            try:
+                grouping_json = json.loads(f.read())
+                groups.append(KanjiGroups(grouping_json["name"], grouping_json["source"], grouping_json["lang"], grouping_json["data"]))
+            except Exception:
+                # rethrow with msg in case a custom file in user_files is outdated
+                raise Exception(f"Failed to load Kanji Grid data file \"{file}\". It might be corrupted or outdated.")
+
+
 def init_groups():
     global groups
     groups = []
-    data_folder = os.path.dirname(__file__) + "/data"
-    for file in os.listdir(data_folder):
-        filepath = data_folder + "/" + file
-        grouping_json = json.loads(open(filepath, encoding = "utf-8").read())
-        groups.append(KanjiGroups(grouping_json["name"], grouping_json["source"], grouping_json["lang"], grouping_json["data"]))
+    cwd = os.path.dirname(__file__)
+    data_folder = cwd + "/data"
+    load_from_folder(groups, data_folder)
+    # user_files persists through addon updates
+    user_files_folder = cwd + "/user_files"
+    load_from_folder(groups, user_files_folder)
 
     groups.sort(key = lambda group: group.name)

--- a/data.py
+++ b/data.py
@@ -29,7 +29,7 @@ def load_from_folder(groups, path):
             groups.append(KanjiGroups(grouping_json["name"], grouping_json["source"], grouping_json["lang"], grouping_json["data"]))
         except Exception:
             # rethrow with msg in case a custom file in user_files is outdated
-            raise Exception(f"Failed to load Kanji Grid data file \"{file}\". It might be corrupted or outdated.")
+            raise Exception(f"Failed to load Kanji Grid data file \"{filepath}\". It might be corrupted or outdated.")
 
 
 def init_groups():


### PR DESCRIPTION
The `user_files` directory [persists across addon upgrades](https://github.com/ankitects/anki/blob/9d1be9a4132533ffd0baa2afa330c0cfc6896cb4/qt/aqt/addons.py#L494) and is thus ideal for hosting custom data files like the nullsp_ce tmw one

This pr makes it loads files from said dir after having gone through the `data` dir.

Users will therefore be responsible for making sure files in the `user_files` dir are compatible with their current kanjigrid version, whereas the files in `data` will be redownloaded along with the addon after each upgrade as usual