### PR TITLE
Fix : Allow sortby value to be set to range(0,5) instead of range(0,4)

### DIFF
--- a/src/config_util.py
+++ b/src/config_util.py
@@ -13,7 +13,7 @@ config_schema = {
     },
     "sortby": {
         "default": 2,
-        "enum": range(0, 4)
+        "enum": range(0, 5)
     },
     "lang": {
         "default": "ja",


### PR DESCRIPTION
I missed that validation during my initial testing, just noticed now when trying to set a default value to the addon 