### PR TITLE
Decouple kanjigrid, config management code, and menu action.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# Data files
+/src/data

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -13,9 +13,15 @@ if __name__ != "__main__" and "pytest" not in sys.modules and is_running_as_addo
     from aqt import mw
 
     from . import kanjigrid
+    from .config_util import KanjiGridConfigProxy
+    from aqt.qt import QAction
+
     # Save a reference to the toolkit onto the mw, preventing garbage collection of PyQt objects
     if mw:
-        mw.kanjigrid = kanjigrid.KanjiGrid(mw)
+        gen_grid_action = QAction("Generate Kanji Grid", mw)
+        mw.kanjigrid = kanjigrid.KanjiGrid(cfg=KanjiGridConfigProxy(mw), menu_action=gen_grid_action)
+        mw.form.menuTools.addSeparator()
+        mw.form.menuTools.addAction(gen_grid_action)
 else:
     print("This is an addon for the Anki spaced repetition learning system and cannot be run directly.")  # noqa: T201
     print("Please download Anki from <https://apps.ankiweb.net/>")  # noqa: T201

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,8 +2,14 @@
 # AnkiWeb:  https://ankiweb.net/shared/info/1610304449
 
 import sys
+import pathlib
 
-if __name__ != "__main__" and "pytest" not in sys.modules:
+
+def is_running_as_addon() -> bool:
+    return pathlib.Path(__file__).parent.parent.name == "addons21"
+
+
+if __name__ != "__main__" and "pytest" not in sys.modules and is_running_as_addon():
     from aqt import mw
 
     from . import kanjigrid

--- a/src/kanjigrid.py
+++ b/src/kanjigrid.py
@@ -29,14 +29,12 @@ from . import config_util, data, generate_grid, save, util, webview_util
 
 
 class KanjiGrid:
-    def __init__(self, cfg: config_util.KanjiGridConfigProxy) -> None:
+    def __init__(self, cfg: config_util.KanjiGridConfigProxy, menu_action: QAction) -> None:
         if not mw:
             raise RuntimeError("mw is None")
         print("STARTING KANJI GRID")
-        self.menuAction = QAction("Generate Kanji Grid", mw, triggered=self.setup)
-        mw.form.menuTools.addSeparator()
-        mw.form.menuTools.addAction(self.menuAction)
         self.cfg = cfg
+        qconnect(menu_action.triggered, self.setup)
 
     def link_handler(self, link: str, config: types.SimpleNamespace, deckname: str) -> None:
         link_prefix = link[:2]

--- a/src/kanjigrid.py
+++ b/src/kanjigrid.py
@@ -29,11 +29,14 @@ from . import config_util, data, generate_grid, save, util, webview_util
 
 
 class KanjiGrid:
-    def __init__(self, mw: main.AnkiQt) -> None:
-        if mw:
-            self.menuAction = QAction("Generate Kanji Grid", mw, triggered=self.setup)
-            mw.form.menuTools.addSeparator()
-            mw.form.menuTools.addAction(self.menuAction)
+    def __init__(self, cfg: config_util.KanjiGridConfigProxy) -> None:
+        if not mw:
+            raise RuntimeError("mw is None")
+        print("STARTING KANJI GRID")
+        self.menuAction = QAction("Generate Kanji Grid", mw, triggered=self.setup)
+        mw.form.menuTools.addSeparator()
+        mw.form.menuTools.addAction(self.menuAction)
+        self.cfg = cfg
 
     def link_handler(self, link: str, config: types.SimpleNamespace, deckname: str) -> None:
         link_prefix = link[:2]
@@ -92,7 +95,7 @@ class KanjiGrid:
             self.displaygrid(config, util.get_deck_name(mw, config), units)
 
     def setup(self) -> None:
-        config = types.SimpleNamespace(**config_util.get_config(mw))
+        config = types.SimpleNamespace(**self.cfg.get_config())
         config.did = mw.col.conf["curDeck"]
         def change_did(deckname: str) -> None:
             if deckname == "*":
@@ -346,7 +349,7 @@ class KanjiGrid:
         data_tab_vertical_layout.addLayout(save_reset_buttons_horizontal_layout)
 
         def save_settings(config: types.SimpleNamespace) -> None:
-            config_util.set_config(mw, set_config_attributes(config))
+            self.cfg.set_config(set_config_attributes(config))
 
         save_settings_button = QPushButton("Save Settings", clicked = lambda _: save_settings(config))
         save_reset_buttons_horizontal_layout.addWidget(save_settings_button)
@@ -354,7 +357,7 @@ class KanjiGrid:
         def reset_settings(setup_win: QDialog) -> None:
             reply = QMessageBox.question(setup_win, "Reset Settings", "Confirm reset settings")
             if reply == QMessageBox.StandardButton.Yes:
-                config_util.reset_config(mw)
+                self.cfg.reset_config()
                 setup_win.reject()
 
         reset_settings_button = QPushButton("Reset Settings", clicked = lambda _: reset_settings(setup_win))


### PR DESCRIPTION
Hey! Added a few changes to make the code more modular. 

* Replace global config functions with the KanjiGridConfigProxy class that reads/writes the config. An instance of the class is passed to KanjiGrid. KanjiGridConfigProxy can be subclassed later to change the behavior without touching the KanjiGrid class itself (e.g. read/write the config file from a different location).
* Move menu registration out of KanjiGrid into __init__. Similarly to the first change, KanjiGrid doesn't need to be a god-like class that does everything.
* In __init__, check if running from the Anki addon directory (addons21). Don't do anything otherwise.
